### PR TITLE
Increase latency_timer from 16 to 160ms

### DIFF
--- a/dynamixel_sdk/src/dynamixel_sdk/port_handler_linux.cpp
+++ b/dynamixel_sdk/src/dynamixel_sdk/port_handler_linux.cpp
@@ -30,7 +30,7 @@
 
 #include "port_handler_linux.h"
 
-#define LATENCY_TIMER  16  // msec (USB latency timer)
+#define LATENCY_TIMER  160  // msec (USB latency timer)
                            // You should adjust the latency timer value. From the version Ubuntu 16.04.2, the default latency timer of the usb serial is '16 msec'.
                            // When you are going to use sync / bulk read, the latency timer should be loosen.
                            // the lower latency timer value, the faster communication speed.


### PR DESCRIPTION
This PR increases the timeout period from `16ms` to `160ms`. This is necessary when creating serial connections over `socat`.

It is worth noting that this increase in the timeout period does not cause any extra delays in the communication (this was tested).